### PR TITLE
upgrade: some quality of life improvements

### DIFF
--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -14,10 +14,12 @@ let finalize (cont : Controller_itp.controller) failed =
   match failed with
   | [] -> begin
       Session_itp.save_session cont.controller_session;
-      Format.printf "Successfully updated session\n"
+      Format.printf "Successfully updated session\n";
+      exit 0
     end
   | _ ->
-      Format.printf "Failed to update session\n"
+      Format.printf "Failed to update session\n";
+      exit 1
 
 open Whyconf
 
@@ -41,10 +43,8 @@ let upgrade_prover (cont : Controller_itp.controller) (upgrade : prover Hprover.
   Format.printf "Upgrading %d proof attempts\n" !remaining;
   Format.print_flush ();
   let finalize () =
-    if !remaining = 0 then begin
-      finalize cont !failed;
-      exit 0
-    end
+    if !remaining = 0 then
+      finalize cont !failed
   in
 
   List.iter

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -91,6 +91,7 @@ let init_env_conf opts =
 
 let load_session why3_opts dir =
   let config, env = init_env_conf why3_opts in
+  Loc.set_warning_hook (fun ?loc:_ _ -> ());
   let files = Queue.create () in
   Queue.push dir files;
   let dir = Server_utils.get_session_dir ~allow_mkdir:false files in


### PR DESCRIPTION
- disable why3 warnings about the session that tend to spam the output (we typically don't care about those when upgrading an existing session)
- have a meaningful error code (convenient for scripting)
- add a --allow-partial option to allow saving a partially upgraded session (useful to later finish the upgrade using why3ide)